### PR TITLE
updated .env-example, remove dotenv

### DIFF
--- a/client/.env-example
+++ b/client/.env-example
@@ -4,7 +4,7 @@ DB_HOST=<database host>
 DB_USER=<database username, for authentication>
 DB_PASS=<database password, for authentication>
 
-GOOGLE_MAPS_API_KEY=<Enter API KEY here>
+REACT_APP_GOOGLE_MAPS_API_KEY=<Enter API KEY here>
 
 LOG_LEVEL=info # the server will use this log level to ignore anything not important enough to appear in the console
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "babel-register": "^6.26.0",
     "body-parser": "~1.18.2",
     "cookie-parser": "~1.4.3",
-    "dotenv": "^5.0.1",
     "express": "~4.15.5",
     "helmet": "^3.12.0",
     "mongoose": "^5.0.8",


### PR DESCRIPTION
noticed that the old .env-example was causing people issues since we are no longer using dotenv and have REACT_APP prefixing the API key. So I had updated this in my new branch, but thought it would be easier and faster to fix it now.
REACT_APP_GOOGLE_MAPS_API_KEY=<Enter API KEY here>

updated .env-example to include the right name and removed the dotenv package from package.json