### PR TITLE
Chore/Added labels to checkboxes for easier clicking

### DIFF
--- a/client/src/features/location-rating/location-rating.component.js
+++ b/client/src/features/location-rating/location-rating.component.js
@@ -25,7 +25,7 @@ export class LocationRating extends Component {
                   this.props.onClickFeature(this.location, feature)
                 }
               />
-              <label for={index}>
+              <label htmlFor={index}>
                 {feature}
               </label>
             </div>

--- a/client/src/features/location-rating/location-rating.component.js
+++ b/client/src/features/location-rating/location-rating.component.js
@@ -19,12 +19,15 @@ export class LocationRating extends Component {
           {this.accessibilityFeatures.map((feature, index) => (
             <div key={index}>
               <input
+                id={index}
                 type="checkbox"
                 onClick={() =>
                   this.props.onClickFeature(this.location, feature)
                 }
               />
-              {feature}
+              <label for={index}>
+                {feature}
+              </label>
             </div>
           ))}
         </div>

--- a/client/src/features/location-rating/location-rating.component.js
+++ b/client/src/features/location-rating/location-rating.component.js
@@ -18,14 +18,14 @@ export class LocationRating extends Component {
         <div>
           {this.accessibilityFeatures.map((feature, index) => (
             <div key={index}>
-              <input
-                id={index}
-                type="checkbox"
-                onClick={() =>
-                  this.props.onClickFeature(this.location, feature)
-                }
-              />
               <label htmlFor={index}>
+                <input
+                  id={index}
+                  type="checkbox"
+                  onClick={() =>
+                    this.props.onClickFeature(this.location, feature)
+                  }
+                />              
                 {feature}
               </label>
             </div>


### PR DESCRIPTION
A little fix to make checking off check boxes easier, for UX and accessibility. Now you can click on the text or the checkbox to check it off.

Edit: After adding labels, we have a new warning:
"LocationRating Form controls using a label to identify them must be programmatically associated with the control using htmlFor See 'https://www.w3.org/WAI/tutorials/forms/labels' for more info."

My last commit has the exact nesting structure recommended at the end of this article:
https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md

I say we need labels for people with fingers larger than the checkbox (everyone). If we need to ignore the false-negative warning, let's ignore it.