### PR TITLE
Fixing bugs on search bar

### DIFF
--- a/client/src/features/auto-complete-list/auto-complete-list.component.js
+++ b/client/src/features/auto-complete-list/auto-complete-list.component.js
@@ -14,10 +14,11 @@ export const Anchor = styled.a`
 
 export class AutoCompleteList extends Component {
   handleClick = (e, index) => {
-    const { updateSearchInput, toggleAutoComplete } = this.props;
+    const { updateSearchInput, toggleAutoComplete, textSearch, userLocation } = this.props;
     e.preventDefault();
     let value = this[index].props.value;
-    updateSearchInput(value);
+    textSearch(value, userLocation.lat, userLocation.lon);
+    updateSearchInput('');
     toggleAutoComplete(false);
   };
 

--- a/client/src/features/auto-complete-list/auto-complete-list.container.js
+++ b/client/src/features/auto-complete-list/auto-complete-list.container.js
@@ -2,14 +2,18 @@ import { connect } from 'react-redux';
 import { AutoCompleteList } from './auto-complete-list.component';
 import { updateSearchInput } from '../search-bar/search-bar.actions';
 import { toggleAutoComplete } from './auto-complete-list.actions';
+import { textSearch } from '../search-bar/search-bar.actions';
+
 
 const mapStateToProps = state => ({
-  autoCompleteList: state.autoCompleteListReducer.autoCompleteList
+  autoCompleteList: state.autoCompleteListReducer.autoCompleteList,
+  userLocation: state.appReducer.userLocation
 });
 
 const mapDispatchToProps = {
   updateSearchInput,
-  toggleAutoComplete
+  toggleAutoComplete,
+  textSearch
 };
 
 export const AutoCompleteListContainer = connect(

--- a/client/src/features/search-bar/search-bar.actions.js
+++ b/client/src/features/search-bar/search-bar.actions.js
@@ -32,8 +32,7 @@ export const updateListItemLocations = locations => {
 
 export const fetchLocations = (searchString, lat, lng) => {
   const APIkey = process.env.REACT_APP_GOOGLE_MAPS_API_KEY;
-
-  const URL = `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${searchString}&types=establishment&location=${lat},${lng}&radius=500&strictbounds&key=${APIkey}
+  const URL = `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${searchString}&location=${lat},${lng}&radius=500&types=establishment&key=${APIkey}
   `;
   return dispatch => {
     return fetch(URL)
@@ -41,7 +40,7 @@ export const fetchLocations = (searchString, lat, lng) => {
       .then(data => {
         const locations = data.predictions
           .slice(0, 5)
-          .map(item => item.description);
+          .map( item => item.description );
         if (locations.length > 0) {
           dispatch(toggleAutoComplete(true));
         }
@@ -58,9 +57,14 @@ export const textSearch = (inputText, lat, lng) => {
     return fetch(URL)
       .then(res => res.json())
       .then(data => {
-        const results = data.results.slice(0, 3).map(item => item.name);
+        const results = data.results.slice(0, 3).map(item => ({
+          name: item.name,
+          lat: item.geometry.location.lat,
+          lon: item.geometry.location.lng
+        }));
         dispatch(updateListItemLocations(results));
       })
       .catch(error => console.log(error));
   };
 };
+

--- a/client/src/features/search-bar/search-bar.component.js
+++ b/client/src/features/search-bar/search-bar.component.js
@@ -46,9 +46,13 @@ export const SearchBar = ({
   };
 
   const handleClick = event => {
-    textSearch(inputValue, userLocation.lat, userLocation.lon);
-    updateSearchInput('');
-    toggleAutoComplete(false);
+    if (!inputValue.trim()) {
+      alert("Ops... Please, enter a location name to search the place!")
+    } else {
+      textSearch(inputValue, userLocation.lat, userLocation.lon);
+      updateSearchInput('');
+      toggleAutoComplete(false);
+    }
   };
 
   return (


### PR DESCRIPTION
Changes:

**fetchLocations**: 
1. removed the parameter strictbounds. 
I'm at Don Mills and if I typed "Rang" it didn't return anything, I expected to see "Rangle".

**textSearch**: 
2. changed data format to match with locations (array of objects) 
the component which list the three places with rate button didn't show anything after a search because the formats were different. I mean, the search overwritten the location data with a different format and the component didn't find the expected information to show on the page.
3. added lat and lon to the result
before we had just the name as string without coordinates.

4. The search is fired when select an item from auto complete list. We don't need click on the search button.

5. Show an alert when the user click on the search button without enter a place or enter only spaces. * For now it is just an alert, I will improve this later.


