### PR TITLE
Chore/Small fix: add words to IDs in checkboxes and labels to remove warnings

### DIFF
--- a/client/src/features/location-rating/location-rating.component.js
+++ b/client/src/features/location-rating/location-rating.component.js
@@ -22,11 +22,11 @@ export class LocationRating extends Component {
         <div>
           {this.accessibilityFeatures.map((feature, index) => (
             <div key={index}>
-              <label htmlFor={index}>
+              <label htmlFor={`rate${index}`}>
                 <input
                   checked={savedToDb ? false : null}
                   type="checkbox"
-                  id={index}
+                  id={`rate${index}`}
                   onClick={() =>
                     this.props.onClickFeature(this.location, feature)
                   }


### PR DESCRIPTION
Looks like the linter doesn't like the IDs to be numbers only.