### PR TITLE
Adding tests to auto-complete list component: actions + reducers

### DIFF
--- a/client/src/features/auto-complete-list/auto-complete-list.actions.test.js
+++ b/client/src/features/auto-complete-list/auto-complete-list.actions.test.js
@@ -1,0 +1,74 @@
+import * as actions from './auto-complete-list.actions';
+import { AUTO_COMPLETE_LIST_TYPES } from './auto-complete-list.types';
+
+describe('action: toggleAutoComplete', () => {
+  it('should return true when receiving true', () => {
+    const bool = true;
+    const expectedAction = {
+      type: AUTO_COMPLETE_LIST_TYPES.toggleAutoComplete,
+      payload: {
+        bool
+      }
+    }
+    expect(actions.toggleAutoComplete(bool)).toEqual(expectedAction)
+  });
+
+  it('should return false when receiving false', () => {
+    const bool = false;
+    const expectedAction = {
+      type: AUTO_COMPLETE_LIST_TYPES.toggleAutoComplete,
+      payload: {
+        bool
+      }
+    }
+    expect(actions.toggleAutoComplete(bool)).toEqual(expectedAction)
+  });
+
+  it('should not return true when receiving a string', () => {
+    const anyString = 'true';
+    const bool = true;
+    const expectedAction = {
+      type: AUTO_COMPLETE_LIST_TYPES.toggleAutoComplete,
+      payload: {
+        bool
+      }
+    }
+    expect(actions.toggleAutoComplete(anyString)).not.toEqual(expectedAction)
+  });
+
+  it('should not return false when receiving a string', () => {
+    const anyString = 'false';
+    const bool = false;
+    const expectedAction = {
+      type: AUTO_COMPLETE_LIST_TYPES.toggleAutoComplete,
+      payload: {
+        bool
+      }
+    }
+    expect(actions.toggleAutoComplete(anyString)).not.toEqual(expectedAction)
+  });
+
+  it('should not return true when receiving a number', () => {
+    const anyNumber = 123;
+    const bool = true;
+    const expectedAction = {
+      type: AUTO_COMPLETE_LIST_TYPES.toggleAutoComplete,
+      payload: {
+        bool
+      }
+    }
+    expect(actions.toggleAutoComplete(anyNumber)).not.toEqual(expectedAction)
+  });
+
+  it('should not return false when receiving a number', () => {
+    const anyNumber = 123;
+    const bool = false;
+    const expectedAction = {
+      type: AUTO_COMPLETE_LIST_TYPES.toggleAutoComplete,
+      payload: {
+        bool
+      }
+    }
+    expect(actions.toggleAutoComplete(anyNumber)).not.toEqual(expectedAction)
+  });
+})

--- a/client/src/features/auto-complete-list/auto-complete-list.reducers.test.js
+++ b/client/src/features/auto-complete-list/auto-complete-list.reducers.test.js
@@ -1,0 +1,115 @@
+import { autoCompleteListReducer } from './auto-complete-list.reducers';
+import { AUTO_COMPLETE_LIST_TYPES } from './auto-complete-list.types';
+import { SEARCH_BAR_TYPES } from '../search-bar/search-bar.types';
+
+describe('auto-complete list reducer', () => {
+  // Case 1: state = undefined, type = empty, payload = empty
+  it('should return the initial state, when received: state = undefined, type = empty, payload = empty', () => {
+    expect(autoCompleteListReducer(undefined, {})).toEqual(
+      {
+        showAutoComplete: false,
+        autoCompleteList: []
+      }
+    )
+  })
+
+  // Case 2: state = expected value, type = empty, payload = empty
+  it('should return the state received, when received: state = expected value, type = empty, payload = empty (default option)', () => {
+    const state = {
+      showAutoComplete: true,
+      autoCompleteList: ['place 1', 'place 2', 'place 3', 'place 4', 'place 5']
+    }
+    expect(autoCompleteListReducer(state, {})).toEqual(
+      state
+    )
+  })
+
+  // Case 3: state = expected value, type = undefined, payload = empty
+  it('should return the state received, when received: state = expected value, type = undefined, payload = empty (default option)', () => {
+    const state = {
+      showAutoComplete: true,
+      autoCompleteList: ['place 1', 'place 2', 'place 3', 'place 4', 'place 5']
+    };
+    const payload = '';
+    expect(autoCompleteListReducer(state, {undefined, payload})).toEqual(
+      state
+    )
+  })
+
+  // Case 4: state = expected value, type = toggleAutoComplete, payload = with bool
+  it('should return the new state, when received: state = expected value, type = toggleAutoComplete, payload = with bool (default toggleAutoComplete)', () => {
+    const state = {
+      showAutoComplete: true,
+      autoCompleteList: ['place 1', 'place 2', 'place 3', 'place 4', 'place 5']
+    };
+    const type = AUTO_COMPLETE_LIST_TYPES.toggleAutoComplete;
+    const payload = {
+      bool: true
+    };
+    expect(autoCompleteListReducer(state, {type, payload})).toEqual(
+      { ...state, showAutoComplete: payload.bool }
+    )
+  })
+
+  // Case 5: state = expected value, type = toggleAutoComplete, payload = without bool
+  it('should return a new state without the payload received, when received: state = expected value, type = toggleAutoComplete, payload = without bool (default toggleAutoComplete)', () => {
+    const state = {
+      showAutoComplete: true,
+      autoCompleteList: ['place 1', 'place 2', 'place 3', 'place 4', 'place 5']
+    };
+    const type = AUTO_COMPLETE_LIST_TYPES.toggleAutoComplete;
+    const payload = {
+      notBool: true
+    };
+    expect(autoCompleteListReducer(state, {type, payload})).not.toEqual(
+      { ...state, showAutoComplete: payload.notBool }
+    )
+  })
+
+  // Case 6: state = expected value, type = addLocations, payload = with locations
+  it('should return the new state, when received: state = expected value, type = addLocations, payload = with locations (default addLocations)', () => {
+    const state = {
+      showAutoComplete: true,
+      autoCompleteList: ['place 1', 'place 2', 'place 3', 'place 4', 'place 5']
+    };
+    const type = SEARCH_BAR_TYPES.addLocations;
+    const payload = {
+      locations: ['place 1', 'place 2', 'place 3', 'place 4', 'place 5', 'place6']
+    };
+    expect(autoCompleteListReducer(state, {type, payload})).toEqual(
+      { ...state, autoCompleteList: payload.locations }
+    )
+  })
+
+  // Case 7: state = expected value, type = addLocations, payload = without locations
+  it('should return a new state without the payload received, when received: state = expected value, type = addLocations, payload = without locations (default addLocations)', () => {
+    const state = {
+      showAutoComplete: true,
+      autoCompleteList: ['place 1', 'place 2', 'place 3', 'place 4', 'place 5']
+    };
+    const type = SEARCH_BAR_TYPES.addLocations;
+    const payload = {
+      notLocations: ['place 1', 'place 2', 'place 3', 'place 4', 'place 5', 'place6']
+    };
+    expect(autoCompleteListReducer(state, {type, payload})).not.toEqual(
+      { ...state, autoCompleteList: payload.notLocations }
+    )
+  })
+
+  // Case 8: state = not expected value, type = addLocations, payload = without locations
+  it('should return a state different than expected, when received: state = not expected value, type = addLocations, payload = with locations (default addLocations)', () => {
+    const state = 'any string';
+    const type = SEARCH_BAR_TYPES.addLocations;
+    const payload = {
+      locations: ['place 1', 'place 2', 'place 3', 'place 4', 'place 5', 'place6']
+    };
+    expect(autoCompleteListReducer(state, {type, payload})).not.toEqual(
+      { 
+        showAutoComplete: true,
+        autoCompleteList: payload.locations 
+      }
+    )
+  })
+
+})
+


### PR DESCRIPTION
Added:
- 6 test cases to sync actions
- 8 test cases to reducers
This component doesn't have async actions.